### PR TITLE
ci(semantic-release): make prerelease identifiers unique for wildcard…

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,9 @@
 {
   "branches": [
     "main",
-    { "name": "story/*", "prerelease": "beta", "channel": "beta" },
-    { "name": "feature/*", "prerelease": "beta", "channel": "beta" },
-    { "name": "release/*", "prerelease": "beta", "channel": "beta" }
+    { "name": "story/*", "prerelease": true, "channel": "beta" },
+    { "name": "feature/*", "prerelease": true, "channel": "beta" },
+    { "name": "release/*", "prerelease": true, "channel": "beta" }
   ],
   "plugins": [
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],


### PR DESCRIPTION
… branches

Use prerelease=true for story/, feature/, release/* so semantic-release derives unique prerelease IDs per branch. Keeps npm channel “beta”. Fixes EPRERELEASEBRANCHES.

