### PR TITLE
ci(semantic-release): restrict branches to main only

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,6 @@
 {
   "branches": [
-    "main",
-    { "name": "story/*", "prerelease": "story", "channel": "beta" },
-    { "name": "feature/*", "prerelease": "feature", "channel": "beta" },
-    { "name": "release/*", "prerelease": "release", "channel": "beta" }
+    "main"
   ],
   "plugins": [
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # openrouter-cli
 
+[![npm latest](https://img.shields.io/npm/v/@letuscode/openrouter-cli)](https://www.npmjs.com/package/@letuscode/openrouter-cli)
+[![npm beta](https://img.shields.io/npm/v/@letuscode/openrouter-cli/beta)](https://www.npmjs.com/package/@letuscode/openrouter-cli?activeTab=versions)
+
 OpenAI‑compatible CLI for OpenRouter. Ask questions, run a REPL, and manage per‑project or global settings.
 
 Requirements


### PR DESCRIPTION
Remove prerelease wildcard patterns from semantic-release config. Pre-releases are managed by beta.yml; avoids EPRERELEASEBRANCHES when multiple story/* branches exist.