### PR TITLE
fix: constrain semantic-release to 0.x version range to prevent 1.x.x…

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,13 @@
 {
   "branches": [
-    "main",
+    {
+      "name": "main",
+      "range": "0.x"
+    },
     {
       "name": "beta",
-      "prerelease": true
+      "prerelease": true,
+      "range": "0.x"
     }
   ],
   "plugins": [


### PR DESCRIPTION
… releases

